### PR TITLE
Add SPMM optimization example

### DIFF
--- a/benchmark/spmm_benchmark.py
+++ b/benchmark/spmm_benchmark.py
@@ -1,0 +1,27 @@
+import argparse
+import time
+import torch
+
+from torch_geometric import EdgeIndex
+from torch_geometric.utils import spmm, spmm_scatter
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--num_nodes', type=int, default=1000)
+parser.add_argument('--num_edges', type=int, default=5000)
+parser.add_argument('--hidden', type=int, default=64)
+parser.add_argument('--runs', type=int, default=10)
+args = parser.parse_args()
+
+row = torch.randint(args.num_nodes, (args.num_edges,))
+col = torch.randint(args.num_nodes, (args.num_edges,))
+edge_index = EdgeIndex(torch.stack([row, col]))
+x = torch.randn(args.num_nodes, args.hidden)
+
+for name, func in [('default', spmm), ('scatter', spmm_scatter)]:
+    times = []
+    for _ in range(args.runs):
+        start = time.time()
+        out = func(edge_index, x)
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        times.append(time.time() - start)
+    print(f'{name}: {sum(times) / len(times):.6f}s')

--- a/examples/gcn_spmm_opt.py
+++ b/examples/gcn_spmm_opt.py
@@ -1,0 +1,129 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.logging import init_wandb, log
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import spmm_scatter
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='Cora')
+parser.add_argument('--hidden_channels', type=int, default=16)
+parser.add_argument('--lr', type=float, default=0.01)
+parser.add_argument('--epochs', type=int, default=200)
+parser.add_argument('--use_gdc', action='store_true', help='Use GDC')
+parser.add_argument('--wandb', action='store_true', help='Track experiment')
+parser.add_argument('--spmm', type=str, default='default',
+                    choices=['default', 'scatter'],
+                    help='Choose SPMM implementation')
+args = parser.parse_args()
+
+device = torch_geometric.device('auto')
+
+init_wandb(
+    name=f'GCN-{args.dataset}',
+    lr=args.lr,
+    epochs=args.epochs,
+    hidden_channels=args.hidden_channels,
+    device=device,
+)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+data = dataset[0].to(device)
+
+if args.use_gdc:
+    transform = T.GDC(
+        self_loop_weight=1,
+        normalization_in='sym',
+        normalization_out='col',
+        diffusion_kwargs=dict(method='ppr', alpha=0.05),
+        sparsification_kwargs=dict(method='topk', k=128, dim=0),
+        exact=True,
+    )
+    data = transform(data)
+
+
+class CustomGCNConv(GCNConv):
+    def message_and_aggregate(self, adj_t, x):
+        if args.spmm == 'scatter':
+            return spmm_scatter(adj_t, x, reduce=self.aggr)
+        return super().message_and_aggregate(adj_t, x)
+
+
+class GCN(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        Conv = CustomGCNConv
+        self.conv1 = Conv(in_channels, hidden_channels,
+                         normalize=not args.use_gdc)
+        self.conv2 = Conv(hidden_channels, out_channels,
+                         normalize=not args.use_gdc)
+
+    def forward(self, x, edge_index, edge_weight=None):
+        x = F.dropout(x, p=0.5, training=self.training)
+        x = self.conv1(x, edge_index, edge_weight).relu()
+        x = F.dropout(x, p=0.5, training=self.training)
+        x = self.conv2(x, edge_index, edge_weight)
+        return x
+
+
+model = GCN(
+    in_channels=dataset.num_features,
+    hidden_channels=args.hidden_channels,
+    out_channels=dataset.num_classes,
+).to(device)
+
+optimizer = torch.optim.Adam([
+    dict(params=model.conv1.parameters(), weight_decay=5e-4),
+    dict(params=model.conv2.parameters(), weight_decay=0)
+], lr=args.lr)  # Only perform weight-decay on first convolution.
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index, data.edge_attr)
+    loss = F.cross_entropy(out[data.train_mask], data.y[data.train_mask])
+    loss.backward()
+    optimizer.step()
+    return float(loss)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    pred = model(data.x, data.edge_index, data.edge_attr).argmax(dim=-1)
+
+    accs = []
+    for mask in [data.train_mask, data.val_mask, data.test_mask]:
+        accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
+    return accs
+
+
+best_val_acc = test_acc = 0
+times = []
+mem = []
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc, val_acc, tmp_test_acc = test()
+    if val_acc > best_val_acc:
+        best_val_acc = val_acc
+        test_acc = tmp_test_acc
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
+    times.append(time.time() - start)
+    if torch.cuda.is_available():
+        mem.append(torch.cuda.max_memory_allocated(device))
+    else:
+        mem.append(0)
+print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')
+if torch.cuda.is_available():
+    print(f'Peak memory usage: {max(mem) / 1024**2:.2f} MB')
+

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -34,6 +34,7 @@ from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
                      to_torch_csc_tensor, to_torch_sparse_tensor,
                      to_edge_index)
 from ._spmm import spmm
+from .custom_spmm import spmm_scatter
 from ._unbatch import unbatch, unbatch_edge_index
 from ._one_hot import one_hot
 from ._normalized_cut import normalized_cut
@@ -112,6 +113,7 @@ __all__ = [
     'to_torch_sparse_tensor',
     'to_edge_index',
     'spmm',
+    'spmm_scatter',
     'unbatch',
     'unbatch_edge_index',
     'one_hot',

--- a/torch_geometric/utils/custom_spmm.py
+++ b/torch_geometric/utils/custom_spmm.py
@@ -1,0 +1,19 @@
+import torch
+from torch import Tensor
+
+from torch_geometric import EdgeIndex
+from torch_geometric.typing import Adj
+from torch_geometric.edge_index import _scatter_spmm
+
+
+def spmm_scatter(src: Adj, other: Tensor, reduce: str = 'sum') -> Tensor:
+    """Sparse-dense matrix multiplication via scatter reduce.
+
+    This utilizes a lightweight scatter-based implementation and can be used
+    as an alternative to :func:`torch_geometric.utils.spmm` for benchmarking
+    purposes.
+    Currently, only :class:`~torch_geometric.EdgeIndex` inputs are supported.
+    """
+    if isinstance(src, EdgeIndex):
+        return _scatter_spmm(src, other, None, reduce, False)
+    raise NotImplementedError("Only 'EdgeIndex' inputs are supported")


### PR DESCRIPTION
## Summary
- add a new example `gcn_spmm_opt.py` that can choose between default and scatter-based SPMM
- provide a lightweight `spmm_scatter` implementation and export it
- expose `spmm_scatter` via `torch_geometric.utils`
- add a simple benchmark script for comparing SPMM methods

## Testing
- `apt-get update -y`
- `apt-get install -y python3-pip`
- **Tests could not run** because PyTorch was missing and installation failed due to network restrictions

------
https://chatgpt.com/codex/tasks/task_e_684a61504cc883278445cb11b84c47d7