### PR TITLE
Add GAT scatter optimization and benchmarking scripts

### DIFF
--- a/benchmark/spmm_benchmark.py
+++ b/benchmark/spmm_benchmark.py
@@ -1,0 +1,27 @@
+import argparse
+import time
+import torch
+
+from torch_geometric import EdgeIndex
+from torch_geometric.utils import spmm, spmm_scatter
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--num_nodes', type=int, default=1000)
+parser.add_argument('--num_edges', type=int, default=5000)
+parser.add_argument('--hidden', type=int, default=64)
+parser.add_argument('--runs', type=int, default=10)
+args = parser.parse_args()
+
+row = torch.randint(args.num_nodes, (args.num_edges,))
+col = torch.randint(args.num_nodes, (args.num_edges,))
+edge_index = EdgeIndex(torch.stack([row, col]))
+x = torch.randn(args.num_nodes, args.hidden)
+
+for name, func in [('default', spmm), ('scatter', spmm_scatter)]:
+    times = []
+    for _ in range(args.runs):
+        start = time.time()
+        out = func(edge_index, x)
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        times.append(time.time() - start)
+    print(f'{name}: {sum(times) / len(times):.6f}s')

--- a/examples/dgl_gcn.py
+++ b/examples/dgl_gcn.py
@@ -1,0 +1,91 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+import dgl
+from dgl.nn import GraphConv
+
+from torch_geometric.datasets import Planetoid
+import torch_geometric.transforms as T
+from torch_geometric.logging import init_wandb, log
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='Cora')
+parser.add_argument('--hidden_channels', type=int, default=16)
+parser.add_argument('--lr', type=float, default=0.01)
+parser.add_argument('--epochs', type=int, default=200)
+parser.add_argument('--wandb', action='store_true')
+args = parser.parse_args()
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+init_wandb(name=f'DGL-GCN-{args.dataset}', hidden_channels=args.hidden_channels,
+           lr=args.lr, epochs=args.epochs, device=device)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+data = dataset[0]
+
+g = dgl.graph((data.edge_index[0], data.edge_index[1]), num_nodes=data.num_nodes)
+features = data.x
+labels = data.y
+train_mask = data.train_mask
+test_mask = data.test_mask
+val_mask = data.val_mask
+
+g = g.to(device)
+features = features.to(device)
+labels = labels.to(device)
+
+
+class DGLGCN(torch.nn.Module):
+    def __init__(self, in_dim, hidden_dim, out_dim):
+        super().__init__()
+        self.conv1 = GraphConv(in_dim, hidden_dim)
+        self.conv2 = GraphConv(hidden_dim, out_dim)
+
+    def forward(self, g, x):
+        x = F.relu(self.conv1(g, x))
+        x = self.conv2(g, x)
+        return x
+
+
+model = DGLGCN(dataset.num_features, args.hidden_channels, dataset.num_classes).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+    out = model(g, features)
+    loss = F.cross_entropy(out[train_mask], labels[train_mask])
+    loss.backward()
+    optimizer.step()
+    return float(loss)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    out = model(g, features)
+    pred = out.argmax(dim=-1)
+    accs = []
+    for mask in [train_mask, val_mask, test_mask]:
+        accs.append(int((pred[mask] == labels[mask]).sum()) / int(mask.sum()))
+    return accs
+
+
+times = []
+best_val = test_acc = 0
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc, val_acc, tmp_test = test()
+    if val_acc > best_val:
+        best_val = val_acc
+        test_acc = tmp_test
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
+    times.append(time.time() - start)
+
+print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')

--- a/examples/gat_spmm_opt.py
+++ b/examples/gat_spmm_opt.py
@@ -1,0 +1,101 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.logging import init_wandb, log
+from torch_geometric.nn import GATConv
+from torch_geometric.utils import spmm_scatter, spmm
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='Cora')
+parser.add_argument('--hidden_channels', type=int, default=8)
+parser.add_argument('--heads', type=int, default=8)
+parser.add_argument('--lr', type=float, default=0.005)
+parser.add_argument('--epochs', type=int, default=200)
+parser.add_argument('--wandb', action='store_true')
+parser.add_argument('--spmm', type=str, default='default', choices=['default', 'scatter'])
+args = parser.parse_args()
+
+device = torch_geometric.device('auto')
+init_wandb(name=f'GAT-{args.dataset}', heads=args.heads, epochs=args.epochs,
+           hidden_channels=args.hidden_channels, lr=args.lr, device=device)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+data = dataset[0].to(device)
+
+
+class CustomGATConv(GATConv):
+    SUPPORTS_FUSED_EDGE_INDEX = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def message_and_aggregate(self, adj_t, x, alpha):
+        x_j = x[0]
+        if args.spmm == 'scatter':
+            return spmm_scatter(adj_t, alpha.unsqueeze(-1) * x_j, reduce=self.aggr)
+        return spmm(adj_t, alpha.unsqueeze(-1) * x_j, reduce=self.aggr)
+
+
+class GAT(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels, heads):
+        super().__init__()
+        Conv = CustomGATConv
+        self.conv1 = Conv(in_channels, hidden_channels, heads, dropout=0.6)
+        self.conv2 = Conv(hidden_channels * heads, out_channels, heads=1,
+                          concat=False, dropout=0.6)
+
+    def forward(self, x, edge_index):
+        x = F.dropout(x, p=0.6, training=self.training)
+        x = F.elu(self.conv1(x, edge_index))
+        x = F.dropout(x, p=0.6, training=self.training)
+        x = self.conv2(x, edge_index)
+        return x
+
+
+model = GAT(dataset.num_features, args.hidden_channels, dataset.num_classes,
+            args.heads).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=5e-4)
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index)
+    loss = F.cross_entropy(out[data.train_mask], data.y[data.train_mask])
+    loss.backward()
+    optimizer.step()
+    return float(loss)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    pred = model(data.x, data.edge_index).argmax(dim=-1)
+
+    accs = []
+    for mask in [data.train_mask, data.val_mask, data.test_mask]:
+        accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
+    return accs
+
+
+best_val_acc = test_acc = 0
+times = []
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc, val_acc, tmp_test_acc = test()
+    if val_acc > best_val_acc:
+        best_val_acc = val_acc
+        test_acc = tmp_test_acc
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
+    times.append(time.time() - start)
+
+print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')

--- a/examples/gcn_spmm_opt.py
+++ b/examples/gcn_spmm_opt.py
@@ -1,0 +1,129 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.logging import init_wandb, log
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import spmm_scatter
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='Cora')
+parser.add_argument('--hidden_channels', type=int, default=16)
+parser.add_argument('--lr', type=float, default=0.01)
+parser.add_argument('--epochs', type=int, default=200)
+parser.add_argument('--use_gdc', action='store_true', help='Use GDC')
+parser.add_argument('--wandb', action='store_true', help='Track experiment')
+parser.add_argument('--spmm', type=str, default='default',
+                    choices=['default', 'scatter'],
+                    help='Choose SPMM implementation')
+args = parser.parse_args()
+
+device = torch_geometric.device('auto')
+
+init_wandb(
+    name=f'GCN-{args.dataset}',
+    lr=args.lr,
+    epochs=args.epochs,
+    hidden_channels=args.hidden_channels,
+    device=device,
+)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+data = dataset[0].to(device)
+
+if args.use_gdc:
+    transform = T.GDC(
+        self_loop_weight=1,
+        normalization_in='sym',
+        normalization_out='col',
+        diffusion_kwargs=dict(method='ppr', alpha=0.05),
+        sparsification_kwargs=dict(method='topk', k=128, dim=0),
+        exact=True,
+    )
+    data = transform(data)
+
+
+class CustomGCNConv(GCNConv):
+    def message_and_aggregate(self, adj_t, x):
+        if args.spmm == 'scatter':
+            return spmm_scatter(adj_t, x, reduce=self.aggr)
+        return super().message_and_aggregate(adj_t, x)
+
+
+class GCN(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        Conv = CustomGCNConv
+        self.conv1 = Conv(in_channels, hidden_channels,
+                         normalize=not args.use_gdc)
+        self.conv2 = Conv(hidden_channels, out_channels,
+                         normalize=not args.use_gdc)
+
+    def forward(self, x, edge_index, edge_weight=None):
+        x = F.dropout(x, p=0.5, training=self.training)
+        x = self.conv1(x, edge_index, edge_weight).relu()
+        x = F.dropout(x, p=0.5, training=self.training)
+        x = self.conv2(x, edge_index, edge_weight)
+        return x
+
+
+model = GCN(
+    in_channels=dataset.num_features,
+    hidden_channels=args.hidden_channels,
+    out_channels=dataset.num_classes,
+).to(device)
+
+optimizer = torch.optim.Adam([
+    dict(params=model.conv1.parameters(), weight_decay=5e-4),
+    dict(params=model.conv2.parameters(), weight_decay=0)
+], lr=args.lr)  # Only perform weight-decay on first convolution.
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index, data.edge_attr)
+    loss = F.cross_entropy(out[data.train_mask], data.y[data.train_mask])
+    loss.backward()
+    optimizer.step()
+    return float(loss)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    pred = model(data.x, data.edge_index, data.edge_attr).argmax(dim=-1)
+
+    accs = []
+    for mask in [data.train_mask, data.val_mask, data.test_mask]:
+        accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
+    return accs
+
+
+best_val_acc = test_acc = 0
+times = []
+mem = []
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc, val_acc, tmp_test_acc = test()
+    if val_acc > best_val_acc:
+        best_val_acc = val_acc
+        test_acc = tmp_test_acc
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
+    times.append(time.time() - start)
+    if torch.cuda.is_available():
+        mem.append(torch.cuda.max_memory_allocated(device))
+    else:
+        mem.append(0)
+print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')
+if torch.cuda.is_available():
+    print(f'Peak memory usage: {max(mem) / 1024**2:.2f} MB')
+

--- a/examples/ogbn_products_loader.py
+++ b/examples/ogbn_products_loader.py
@@ -1,0 +1,99 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+from ogb.nodeproppred import PygNodePropPredDataset, Evaluator
+
+from torch_geometric import device
+from torch_geometric.loader import NeighborLoader
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import spmm_scatter, spmm
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--hidden_channels', type=int, default=64)
+parser.add_argument('--lr', type=float, default=0.01)
+parser.add_argument('--epochs', type=int, default=5)
+parser.add_argument('--batch_size', type=int, default=1024)
+parser.add_argument('--spmm', type=str, default='default', choices=['default', 'scatter'])
+args = parser.parse_args()
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+dataset = PygNodePropPredDataset('ogbn-products', root=osp.join('data', 'OGB'))
+data = dataset[0]
+split_idx = dataset.get_idx_split()
+
+train_loader = NeighborLoader(
+    data,
+    num_neighbors=[10, 10],
+    input_nodes=split_idx['train'],
+    batch_size=args.batch_size,
+    shuffle=True,
+)
+
+
+eval_loader = NeighborLoader(
+    data,
+    num_neighbors=[10, 10],
+    input_nodes=torch.cat([split_idx['valid'], split_idx['test']]),
+    batch_size=args.batch_size,
+    shuffle=False,
+)
+
+
+class CustomGCNConv(GCNConv):
+    def message_and_aggregate(self, adj_t, x):
+        if args.spmm == 'scatter':
+            return spmm_scatter(adj_t, x, reduce=self.aggr)
+        return spmm(adj_t, x, reduce=self.aggr)
+
+
+class GCN(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        Conv = CustomGCNConv
+        self.conv1 = Conv(in_channels, hidden_channels)
+        self.conv2 = Conv(hidden_channels, out_channels)
+
+    def forward(self, x, edge_index):
+        x = F.relu(self.conv1(x, edge_index))
+        x = self.conv2(x, edge_index)
+        return x
+
+
+def train(loader):
+    model.train()
+    total_loss = 0
+    for batch in loader:
+        batch = batch.to(device)
+        optimizer.zero_grad()
+        out = model(batch.x, batch.edge_index)
+        loss = F.cross_entropy(out, batch.y.squeeze())
+        loss.backward()
+        optimizer.step()
+        total_loss += float(loss) * batch.num_nodes
+    return total_loss / len(loader.dataset)
+
+
+def test(loader):
+    model.eval()
+    correct = 0
+    evaluator = Evaluator('ogbn-products')
+    for batch in loader:
+        batch = batch.to(device)
+        out = model(batch.x, batch.edge_index)
+        pred = out.argmax(dim=-1, keepdim=True)
+        correct += evaluator.eval({'y_true': batch.y, 'y_pred': pred})['acc'] * batch.num_nodes
+    return correct / len(loader.dataset)
+
+
+model = GCN(dataset.num_features, args.hidden_channels, dataset.num_classes).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train(train_loader)
+    acc = test(eval_loader)
+    print(f'Epoch: {epoch:02d}, Loss: {loss:.4f}, Acc: {acc:.4f}, Time: {time.time()-start:.2f}s')

--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -1,0 +1,19 @@
+import argparse
+import matplotlib.pyplot as plt
+import pandas as pd
+
+parser = argparse.ArgumentParser()
+parser.add_argument('csv', type=str, help='Path to log CSV file')
+parser.add_argument('--out', type=str, default='metrics.png')
+args = parser.parse_args()
+
+log = pd.read_csv(args.csv)
+fig, ax1 = plt.subplots()
+ax1.plot(log['epoch'], log['time'], label='time')
+ax1.set_xlabel('Epoch')
+ax1.set_ylabel('Time (s)')
+ax2 = ax1.twinx()
+ax2.plot(log['epoch'], log['acc'], color='orange', label='acc')
+ax2.set_ylabel('Accuracy')
+fig.tight_layout()
+plt.savefig(args.out)

--- a/test/utils/test_spmm_scatter.py
+++ b/test/utils/test_spmm_scatter.py
@@ -1,0 +1,19 @@
+import torch
+
+from torch_geometric import EdgeIndex
+from torch_geometric.testing import withCUDA
+from torch_geometric.utils import spmm, spmm_scatter
+
+
+@withCUDA
+def test_spmm_scatter_equivalence(device):
+    src = EdgeIndex(
+        [[0, 1, 1, 2], [1, 0, 2, 1]],
+        sparse_size=(4, 3),
+        sort_order='row',
+        device=device,
+    )
+    other = torch.randn(3, 4, device=device)
+    out1 = spmm(src.flip(0), other)
+    out2 = spmm_scatter(src.flip(0), other)
+    assert torch.allclose(out1, out2, atol=1e-6)

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -34,6 +34,7 @@ from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
                      to_torch_csc_tensor, to_torch_sparse_tensor,
                      to_edge_index)
 from ._spmm import spmm
+from .custom_spmm import spmm_scatter
 from ._unbatch import unbatch, unbatch_edge_index
 from ._one_hot import one_hot
 from ._normalized_cut import normalized_cut
@@ -112,6 +113,7 @@ __all__ = [
     'to_torch_sparse_tensor',
     'to_edge_index',
     'spmm',
+    'spmm_scatter',
     'unbatch',
     'unbatch_edge_index',
     'one_hot',

--- a/torch_geometric/utils/custom_spmm.py
+++ b/torch_geometric/utils/custom_spmm.py
@@ -1,0 +1,19 @@
+import torch
+from torch import Tensor
+
+from torch_geometric import EdgeIndex
+from torch_geometric.typing import Adj
+from torch_geometric.edge_index import _scatter_spmm
+
+
+def spmm_scatter(src: Adj, other: Tensor, reduce: str = 'sum') -> Tensor:
+    """Sparse-dense matrix multiplication via scatter reduce.
+
+    This utilizes a lightweight scatter-based implementation and can be used
+    as an alternative to :func:`torch_geometric.utils.spmm` for benchmarking
+    purposes.
+    Currently, only :class:`~torch_geometric.EdgeIndex` inputs are supported.
+    """
+    if isinstance(src, EdgeIndex):
+        return _scatter_spmm(src, other, None, reduce, False)
+    raise NotImplementedError("Only 'EdgeIndex' inputs are supported")


### PR DESCRIPTION
## Summary
- implement `gat_spmm_opt.py` to benchmark scatter SPMM with GAT
- add DGL-based GCN example for framework comparison
- provide a NeighborLoader example on OGBN-Products
- supply a simple plotting utility for logged metrics
- test `spmm_scatter` equivalence with default `spmm`

## Testing
- `pytest -k spmm_scatter -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684a61504cc883278445cb11b84c47d7